### PR TITLE
Adding oauth-sign module to frontend/package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -84,6 +84,7 @@
     "dotenv-webpack": "^1.7.0",
     "jest": "^24.8.0",
     "moment": "^2.24.0",
+    "oauth-sign": "^0.9.0",
     "raf": "^3.4.1",
     "react": "^16.8.6",
     "react-copy-to-clipboard": "^5.0.1",


### PR DESCRIPTION
Struggled through this missing dependency found that it was required for the front-end npm run test. Figured this was NOT intentional as other students are hitting this as well. See https://knowledge.udacity.com/questions/345792